### PR TITLE
Bulk changed urls from vienna-rss.org to vienna-rss.com

### DIFF
--- a/_posts/2010-01-08-hello-world.markdown
+++ b/_posts/2010-01-08-hello-world.markdown
@@ -12,7 +12,7 @@ author_login: Michael Stroeck
 author_email: michael@stroeck.com
 author_url: http://www.twitter.com/mstroeck
 wordpress_id: 1
-wordpress_url: http://www.vienna-rss.org/?p=1
+wordpress_url: http://www.vienna-rss.com/?p=1
 date: '2010-01-08 16:38:29 +1100'
 date_gmt: '2010-01-08 16:38:29 +1100'
 categories:

--- a/_posts/2010-01-12-vienna-2-4-released.markdown
+++ b/_posts/2010-01-12-vienna-2-4-released.markdown
@@ -12,7 +12,7 @@ author_login: Michael Stroeck
 author_email: michael@stroeck.com
 author_url: http://www.twitter.com/mstroeck
 wordpress_id: 108
-wordpress_url: http://www.vienna-rss.org/?p=108
+wordpress_url: http://www.vienna-rss.com/?p=108
 date: '2010-01-12 17:56:45 +1100'
 date_gmt: '2010-01-12 17:56:45 +1100'
 categories:

--- a/_posts/2010-01-18-a-vienna-2-5-sneak-peek.markdown
+++ b/_posts/2010-01-18-a-vienna-2-5-sneak-peek.markdown
@@ -12,7 +12,7 @@ author_login: Michael Stroeck
 author_email: michael@stroeck.com
 author_url: http://www.twitter.com/mstroeck
 wordpress_id: 201
-wordpress_url: http://www.vienna-rss.org/?p=201
+wordpress_url: http://www.vienna-rss.com/?p=201
 date: '2010-01-18 12:01:56 +1100'
 date_gmt: '2010-01-18 12:01:56 +1100'
 categories:
@@ -30,7 +30,7 @@ comments:
 - id: 16
   author: Vienna Administrators
   author_email: vienna-rss-admins@sourceforge.net
-  author_url: http://www.vienna-rss.org
+  author_url: http://www.vienna-rss.com
   date: '2010-01-19 10:39:09 +1100'
   date_gmt: '2010-01-19 10:39:09 +1100'
   content: Thanks, David :-)
@@ -44,7 +44,7 @@ comments:
 - id: 59
   author: Vienna Administrators
   author_email: vienna-rss-admins@sourceforge.net
-  author_url: http://www.vienna-rss.org
+  author_url: http://www.vienna-rss.com
   date: '2010-02-07 15:03:07 +1100'
   date_gmt: '2010-02-07 15:03:07 +1100'
   content: We agree :-) It is tentatively in the works for after 2.5, which will hit
@@ -52,7 +52,7 @@ comments:
 - id: 62
   author: uberVU - social comments
   author_email: ''
-  author_url: http://www.ubervu.com/conversations/www.vienna-rss.org/%3Fp%3D201
+  author_url: http://www.ubervu.com/conversations/www.vienna-rss.com/%3Fp%3D201
   date: '2010-02-08 00:37:01 +1100'
   date_gmt: '2010-02-08 00:37:01 +1100'
   content: |-
@@ -72,7 +72,7 @@ comments:
 - id: 92
   author: Vienna Administrators
   author_email: vienna-rss-admins@sourceforge.net
-  author_url: http://www.vienna-rss.org
+  author_url: http://www.vienna-rss.com
   date: '2010-02-11 16:23:47 +1100'
   date_gmt: '2010-02-11 16:23:47 +1100'
   content: Does any other news-reader do that? I'd be interested in how to do that
@@ -100,12 +100,12 @@ comments:
 - id: 114
   author: Vienna Administrators
   author_email: vienna-rss-admins@sourceforge.net
-  author_url: http://www.vienna-rss.org
+  author_url: http://www.vienna-rss.com
   date: '2010-02-14 22:51:14 +1100'
   date_gmt: '2010-02-14 22:51:14 +1100'
   content: I don't use Instapaper, but it should be possible to write a plugin for
     that.
 ---
-<p>Vienna 2.5 will bring support for <a href="http:&#47;&#47;www.vienna-rss.org&#47;?page_id=120">plugins<&#47;a> that are extremely easy to create, but at the same time are powerful enough to tailor Vienna to your needs. At the time of writing, there are two type of plugins: Link Plugins and Script Plugins. 2.5 will ship with at least three built-in ones: Share with <strong>Facebook<&#47;strong>, Share with <strong>Evernote<&#47;strong>, Share with <strong>Twitter<&#47;strong>:<br />
-<center><img alt="Vienna 2.5 supports user-creatable plugins" src="http:&#47;&#47;www.vienna-rss.org&#47;img&#47;plugins.png" title="Vienna 2.5 supports user-creatable plugins" width="327" height="77" &#47;><&#47;center><br />
-<strong>URL shortening<&#47;strong> happens automatically via bit.ly and is available to all plugins, all you need to do is a click a checkbox when you are creating yours. For more information, go read the <a href="http:&#47;&#47;www.vienna-rss.org&#47;?page_id=120">documentation<&#47;a>. If you have questions or feedback, there's a thread about this topic on <a href="http:&#47;&#47;forums.cocoaforge.com&#47;viewtopic.php?f=18&t=21783">our forum<&#47;a>.</p>
+<p>Vienna 2.5 will bring support for <a href="http:&#47;&#47;www.vienna-rss.com&#47;?page_id=120">plugins<&#47;a> that are extremely easy to create, but at the same time are powerful enough to tailor Vienna to your needs. At the time of writing, there are two type of plugins: Link Plugins and Script Plugins. 2.5 will ship with at least three built-in ones: Share with <strong>Facebook<&#47;strong>, Share with <strong>Evernote<&#47;strong>, Share with <strong>Twitter<&#47;strong>:<br />
+<center><img alt="Vienna 2.5 supports user-creatable plugins" src="http:&#47;&#47;www.vienna-rss.com&#47;img&#47;plugins.png" title="Vienna 2.5 supports user-creatable plugins" width="327" height="77" &#47;><&#47;center><br />
+<strong>URL shortening<&#47;strong> happens automatically via bit.ly and is available to all plugins, all you need to do is a click a checkbox when you are creating yours. For more information, go read the <a href="http:&#47;&#47;www.vienna-rss.com&#47;?page_id=120">documentation<&#47;a>. If you have questions or feedback, there's a thread about this topic on <a href="http:&#47;&#47;forums.cocoaforge.com&#47;viewtopic.php?f=18&t=21783">our forum<&#47;a>.</p>

--- a/_posts/2010-01-20-idns-and-cocoa.markdown
+++ b/_posts/2010-01-20-idns-and-cocoa.markdown
@@ -12,7 +12,7 @@ author_login: Michael Stroeck
 author_email: michael@stroeck.com
 author_url: http://www.twitter.com/mstroeck
 wordpress_id: 215
-wordpress_url: http://www.vienna-rss.org/?p=215
+wordpress_url: http://www.vienna-rss.com/?p=215
 date: '2010-01-20 19:53:08 +1100'
 date_gmt: '2010-01-20 19:53:08 +1100'
 categories:
@@ -32,7 +32,7 @@ comments:
 - id: 18
   author: Vienna Administrators
   author_email: vienna-rss-admins@sourceforge.net
-  author_url: http://www.vienna-rss.org
+  author_url: http://www.vienna-rss.com
   date: '2010-01-21 04:40:40 +1100'
   date_gmt: '2010-01-21 04:40:40 +1100'
   content: No, it doesn't. It only Percent-Escapes.

--- a/_posts/2010-02-08-vienna-2-5-beta.markdown
+++ b/_posts/2010-02-08-vienna-2-5-beta.markdown
@@ -12,7 +12,7 @@ author_login: Michael Stroeck
 author_email: michael@stroeck.com
 author_url: http://www.twitter.com/mstroeck
 wordpress_id: 237
-wordpress_url: http://www.vienna-rss.org/?p=237
+wordpress_url: http://www.vienna-rss.com/?p=237
 date: '2010-02-08 13:07:13 +1100'
 date_gmt: '2010-02-08 13:07:13 +1100'
 categories:
@@ -23,7 +23,7 @@ comments:
 - id: 66
   author: uberVU - social comments
   author_email: ''
-  author_url: http://www.ubervu.com/conversations/www.vienna-rss.org/%3Fp%3D237
+  author_url: http://www.ubervu.com/conversations/www.vienna-rss.com/%3Fp%3D237
   date: '2010-02-08 14:56:26 +1100'
   date_gmt: '2010-02-08 14:56:26 +1100'
   content: |-
@@ -33,7 +33,7 @@ comments:
 - id: 91
   author: Vienna Administrators
   author_email: vienna-rss-admins@sourceforge.net
-  author_url: http://www.vienna-rss.org
+  author_url: http://www.vienna-rss.com
   date: '2010-02-11 16:22:08 +1100'
   date_gmt: '2010-02-11 16:22:08 +1100'
   content: 'I agree that it would be nice. However: We''re not in competition with
@@ -44,7 +44,7 @@ comments:
     open source developers scratch their own itch first and foremost.. It''s an undocumented
     API, after all...'
 ---
-<p>The Vienna Development team is happy to announce the beta release of Vienna 2.5. This is a testing release that, among other things, adds extendability via a new <a href="http:&#47;&#47;www.vienna-rss.org&#47;?page_id=120">plugin development API<&#47;a> and fixes a small number of bugs. To be more precise, the new plugins make it extremely simple to extend Vienna with sharing capabilities that leverage social networking sites like <a href="http:&#47;&#47;www.facebook.com">Facebook<&#47;a> and <a href="http:&#47;&#47;www.twitter.com&#47;ViennaRSS">Twitter<&#47;a>. <center><a href="https:&#47;&#47;sourceforge.net&#47;projects&#47;vienna-rss&#47;files&#47;TestVersions&#47;2.5.0.2500&#47;Vienna2.5.0.2500-BETA.zip&#47;download"><img alt="Vienna 2.5 supports user-creatable plugins" src="http:&#47;&#47;www.vienna-rss.org&#47;img&#47;plugins.png" title="Vienna 2.5 supports user-creatable plugins" width="327" height="77" &#47;><&#47;a><br&#47;><br />
+<p>The Vienna Development team is happy to announce the beta release of Vienna 2.5. This is a testing release that, among other things, adds extendability via a new <a href="http:&#47;&#47;www.vienna-rss.com&#47;?page_id=120">plugin development API<&#47;a> and fixes a small number of bugs. To be more precise, the new plugins make it extremely simple to extend Vienna with sharing capabilities that leverage social networking sites like <a href="http:&#47;&#47;www.facebook.com">Facebook<&#47;a> and <a href="http:&#47;&#47;www.twitter.com&#47;ViennaRSS">Twitter<&#47;a>. <center><a href="https:&#47;&#47;sourceforge.net&#47;projects&#47;vienna-rss&#47;files&#47;TestVersions&#47;2.5.0.2500&#47;Vienna2.5.0.2500-BETA.zip&#47;download"><img alt="Vienna 2.5 supports user-creatable plugins" src="http:&#47;&#47;www.vienna-rss.com&#47;img&#47;plugins.png" title="Vienna 2.5 supports user-creatable plugins" width="327" height="77" &#47;><&#47;a><br&#47;><br />
 <h3>Click to download: <a href="https:&#47;&#47;sourceforge.net&#47;projects&#47;vienna-rss&#47;files&#47;TestVersions&#47;2.5.0.2500&#47;Vienna2.5.0.2500-BETA.zip&#47;download"><strong>Vienna 2.5 BETA<&#47;strong><&#47;a><&#47;h3><&#47;center></p>
 <h3>Requirements<&#47;h3><br />
 Vienna 2.5 BETA <strong>requires Mac OS X 10.5<&#47;strong> Leopard or higher to run.</p>
@@ -52,7 +52,7 @@ Vienna 2.5 BETA <strong>requires Mac OS X 10.5<&#47;strong> Leopard or higher to
 The Vienna 2.5 BETA version is pre-release software, and it may contain bugs. If you discover a bug, please create a new topic here in the Vienna forum and report the bug to us. Some tips for writing good bug reports can be found at <a href="http:&#47;&#47;forums.cocoaforge.com&#47;viewtopic.php?f=18&t=9210">http:&#47;&#47;forums.cocoaforge.com&#47;viewtopic.php?f=18&t=9210<&#47;a>. For safety, we recommend that you back up your files before running the beta version. Vienna's files are located at "~&#47;Library&#47;Preferences&#47;uk.co.opencommunity.vienna2.plist" and "~&#47;Library&#47;Application Support&#47;Vienna". When 2.5 goes out of beta, Vienna will automatically update to the release version.</p>
 <h3>New features<&#47;h3></p>
 <ul>
-<li>Add support for <strong>plugins<&#47;strong>. For details, see the <a href="http:&#47;&#47;www.vienna-rss.org&#47;?page_id=120">Plugin Documentation<&#47;a>.
+<li>Add support for <strong>plugins<&#47;strong>. For details, see the <a href="http:&#47;&#47;www.vienna-rss.com&#47;?page_id=120">Plugin Documentation<&#47;a>.
 <li>Add a facility for automatic URL shortening via bit.ly that can be used by all plugins.
 <li>Add <strong>"Share with Twitter"<&#47;strong> plugin and toolbar button.
 <li>Add <strong>"Share with Facebook"<&#47;strong> plugin and toolbar button.

--- a/_posts/2010-02-23-devs-teach-your-app-about-vienna-nnw-and-others.markdown
+++ b/_posts/2010-02-23-devs-teach-your-app-about-vienna-nnw-and-others.markdown
@@ -12,7 +12,7 @@ author_login: Michael Stroeck
 author_email: michael@stroeck.com
 author_url: http://www.twitter.com/mstroeck
 wordpress_id: 277
-wordpress_url: http://www.vienna-rss.org/?p=277
+wordpress_url: http://www.vienna-rss.com/?p=277
 date: '2010-02-23 12:37:33 +1100'
 date_gmt: '2010-02-23 12:37:33 +1100'
 categories:

--- a/_posts/2010-03-19-vienna-2-5-the-social-sharing-edition.markdown
+++ b/_posts/2010-03-19-vienna-2-5-the-social-sharing-edition.markdown
@@ -12,7 +12,7 @@ author_login: Michael Stroeck
 author_email: michael@stroeck.com
 author_url: http://www.twitter.com/mstroeck
 wordpress_id: 285
-wordpress_url: http://www.vienna-rss.org/?p=285
+wordpress_url: http://www.vienna-rss.com/?p=285
 date: '2010-03-19 09:18:39 +1100'
 date_gmt: '2010-03-19 09:18:39 +1100'
 categories:
@@ -23,7 +23,7 @@ comments:
 - id: 413
   author: uberVU - social comments
   author_email: ''
-  author_url: http://www.ubervu.com/conversations/www.vienna-rss.org/%3Fp%3D285
+  author_url: http://www.ubervu.com/conversations/www.vienna-rss.com/%3Fp%3D285
   date: '2010-03-19 10:36:35 +1100'
   date_gmt: '2010-03-19 10:36:35 +1100'
   content: |-
@@ -31,7 +31,7 @@ comments:
 
     This post was mentioned on Twitter by ViennaRSS: Vienna 2.5 (Social Sharing Edition) released: http:&#47;&#47;bit.ly&#47;9gEnSo...
 ---
-<p>The Vienna Dev Team is proud to announce the release of Vienna 2.5. Among other things, it adds extendability via a new <a href="http:&#47;&#47;www.vienna-rss.org&#47;?page_id=120">plugin development API<&#47;a> and fixes a small number of bugs. To be more precise, the new plugins make it extremely simple to extend Vienna with sharing capabilities that leverage social networking sites like <a href="http:&#47;&#47;www.facebook.com">Facebook<&#47;a> and <a href="http:&#47;&#47;www.twitter.com&#47;ViennaRSS">Twitter<&#47;a>. Special thanks go to <a href="http:&#47;&#47;www.curtisfaith.com">Curtis Faith<&#47;a>, who contributed bug fixes for this release. <center><a href="http:&#47;&#47;sourceforge.net&#47;projects&#47;vienna-rss&#47;files&#47;ReleasedVersions&#47;2.5.0&#47;Vienna2.5.0.2501.zip&#47;download"><img alt="Vienna 2.5 supports user-creatable plugins" src="http:&#47;&#47;www.vienna-rss.org&#47;img&#47;plugins.png" title="Vienna 2.5 supports user-creatable plugins" width="327" height="77" &#47;><&#47;a><br&#47;><br />
+<p>The Vienna Dev Team is proud to announce the release of Vienna 2.5. Among other things, it adds extendability via a new <a href="http:&#47;&#47;www.vienna-rss.com&#47;?page_id=120">plugin development API<&#47;a> and fixes a small number of bugs. To be more precise, the new plugins make it extremely simple to extend Vienna with sharing capabilities that leverage social networking sites like <a href="http:&#47;&#47;www.facebook.com">Facebook<&#47;a> and <a href="http:&#47;&#47;www.twitter.com&#47;ViennaRSS">Twitter<&#47;a>. Special thanks go to <a href="http:&#47;&#47;www.curtisfaith.com">Curtis Faith<&#47;a>, who contributed bug fixes for this release. <center><a href="http:&#47;&#47;sourceforge.net&#47;projects&#47;vienna-rss&#47;files&#47;ReleasedVersions&#47;2.5.0&#47;Vienna2.5.0.2501.zip&#47;download"><img alt="Vienna 2.5 supports user-creatable plugins" src="http:&#47;&#47;www.vienna-rss.com&#47;img&#47;plugins.png" title="Vienna 2.5 supports user-creatable plugins" width="327" height="77" &#47;><&#47;a><br&#47;><br />
 <h3>Click to download: <a href="http:&#47;&#47;sourceforge.net&#47;projects&#47;vienna-rss&#47;files&#47;ReleasedVersions&#47;2.5.0&#47;Vienna2.5.0.2501.zip&#47;download"><strong>Vienna 2.5<&#47;strong><&#47;a><&#47;h3><&#47;center></p>
 <h3>Requirements<&#47;h3><br />
 This release requires <strong>Mac OS X 10.5 (Leopard)<&#47;strong> to run.</p>

--- a/_posts/2010-03-25-thanks.markdown
+++ b/_posts/2010-03-25-thanks.markdown
@@ -12,7 +12,7 @@ author_login: Michael Stroeck
 author_email: michael@stroeck.com
 author_url: http://www.twitter.com/mstroeck
 wordpress_id: 303
-wordpress_url: http://www.vienna-rss.org/?p=303
+wordpress_url: http://www.vienna-rss.com/?p=303
 date: '2010-03-25 21:03:32 +1100'
 date_gmt: '2010-03-25 21:03:32 +1100'
 categories:

--- a/_posts/2010-03-31-new-developer-curtis-faith-and-a-sneak-peek.markdown
+++ b/_posts/2010-03-31-new-developer-curtis-faith-and-a-sneak-peek.markdown
@@ -12,7 +12,7 @@ author_login: Michael Stroeck
 author_email: michael@stroeck.com
 author_url: http://www.twitter.com/mstroeck
 wordpress_id: 309
-wordpress_url: http://www.vienna-rss.org/?p=309
+wordpress_url: http://www.vienna-rss.com/?p=309
 date: '2010-03-31 08:56:30 +1100'
 date_gmt: '2010-03-31 08:56:30 +1100'
 categories:
@@ -23,4 +23,4 @@ tags: []
 comments: []
 ---
 <p>Today, we would like to introduce a new contributor: <a href="http:&#47;&#47;www.curtisfaith.com&#47;">Curtis Faith<&#47;a> (a.k.a. <em>inflector<&#47;em> on the <a href="http:&#47;&#47;forums.cocoaforge.com&#47;viewforum.php?f=18">Forum<&#47;a>). He's not only a very <a href="http:&#47;&#47;www.amazon.com&#47;gp&#47;product&#47;0137047681?ie=UTF8&tag=curtisfaith-20&linkCode=as2&camp=1789&creative=9325&creativeASIN=0137047681">interesting<&#47;a> <a href="http:&#47;&#47;www.amazon.com&#47;gp&#47;product&#47;007148664X?ie=UTF8&tag=curtisfaith-20&linkCode=as2&camp=1789&creative=9325&creativeASIN=007148664X">author<&#47;a> but also, it turns out, a great programmer. You can download an alpha version of Vienna 2.6 that includes a handy new feature added by him:<a href="http:&#47;&#47;forums.cocoaforge.com&#47;viewtopic.php?f=18&t=22029"> Full Web-Page Feeds<&#47;a>. This is very handy for sites that only put headlines or very short summaries in their feeds. You can now set those to immediately load the associated web-page in the reading-pane:<br />
-<img src="http:&#47;&#47;www.vienna-rss.org&#47;img&#47;fwpf.png" alt="Full Web Page Feds"></p>
+<img src="http:&#47;&#47;www.vienna-rss.com&#47;img&#47;fwpf.png" alt="Full Web Page Feds"></p>

--- a/_posts/2011-06-26-vienna-2-6-beta.markdown
+++ b/_posts/2011-06-26-vienna-2-6-beta.markdown
@@ -12,7 +12,7 @@ author_login: Michael Stroeck
 author_email: michael@stroeck.com
 author_url: http://www.twitter.com/mstroeck
 wordpress_id: 334
-wordpress_url: http://www.vienna-rss.org/?p=334
+wordpress_url: http://www.vienna-rss.com/?p=334
 date: '2011-06-26 15:35:21 +1000'
 date_gmt: '2011-06-26 15:35:21 +1000'
 categories:

--- a/_posts/2011-08-29-vienna-development-moves-to-github.markdown
+++ b/_posts/2011-08-29-vienna-development-moves-to-github.markdown
@@ -12,7 +12,7 @@ author_login: Michael Stroeck
 author_email: michael@stroeck.com
 author_url: http://www.twitter.com/mstroeck
 wordpress_id: 358
-wordpress_url: http://www.vienna-rss.org/?p=358
+wordpress_url: http://www.vienna-rss.com/?p=358
 date: '2011-08-29 21:03:49 +1000'
 date_gmt: '2011-08-29 21:03:49 +1000'
 categories:
@@ -40,7 +40,7 @@ comments:
 - id: 5319
   author: Vienna Administrators
   author_email: vienna-rss-admins@sourceforge.net
-  author_url: http://www.vienna-rss.org
+  author_url: http://www.vienna-rss.com
   date: '2011-09-22 08:57:31 +1000'
   date_gmt: '2011-09-22 08:57:31 +1000'
   content: |-

--- a/_posts/2011-12-18-2-6-out-of-beta.markdown
+++ b/_posts/2011-12-18-2-6-out-of-beta.markdown
@@ -12,7 +12,7 @@ author_login: Michael Stroeck
 author_email: michael@stroeck.com
 author_url: http://www.twitter.com/mstroeck
 wordpress_id: 366
-wordpress_url: http://www.vienna-rss.org/?p=366
+wordpress_url: http://www.vienna-rss.com/?p=366
 date: '2011-12-18 19:06:24 +1100'
 date_gmt: '2011-12-18 19:06:24 +1100'
 categories:
@@ -38,7 +38,7 @@ comments:
 - id: 5417
   author: Vienna Administrators
   author_email: vienna-rss-admins@sourceforge.net
-  author_url: http://www.vienna-rss.org
+  author_url: http://www.vienna-rss.com
   date: '2011-12-19 04:14:31 +1100'
   date_gmt: '2011-12-19 04:14:31 +1100'
   content: That is rather weird - it worked on all our test machines. Please download
@@ -161,5 +161,5 @@ comments:
     of Mac OS X. Is there an other way?'
 ---
 <p>2.6 has been stable for a very, very long time - so I'll just make it official :-) One small but handy thing that I added is a plugin for effortless sharing with <a href="http:&#47;&#47;www.bufferapp.com">Buffer<&#47;a>. It's a very useful service that has popped up between the beta release and now - check it out and have fun!</p>
-<p><center><a href="http:&#47;&#47;sourceforge.net&#47;projects&#47;vienna-rss&#47;files&#47;ReleasedVersions&#47;2.6.0&#47;Vienna2.6.0.2601.zip&#47;download"><img alt="Vienna 2.6 supports user-creatable plugins" src="http:&#47;&#47;www.vienna-rss.org&#47;img&#47;plugins.png" title="Vienna 2.6 supports user-creatable plugins" width="327" height="77" &#47;><&#47;a><br&#47;><br />
+<p><center><a href="http:&#47;&#47;sourceforge.net&#47;projects&#47;vienna-rss&#47;files&#47;ReleasedVersions&#47;2.6.0&#47;Vienna2.6.0.2601.zip&#47;download"><img alt="Vienna 2.6 supports user-creatable plugins" src="http:&#47;&#47;www.vienna-rss.com&#47;img&#47;plugins.png" title="Vienna 2.6 supports user-creatable plugins" width="327" height="77" &#47;><&#47;a><br&#47;><br />
 <h3>Click to download: <a href="http:&#47;&#47;sourceforge.net&#47;projects&#47;vienna-rss&#47;files&#47;ReleasedVersions&#47;2.6.0&#47;Vienna2.6.0.2601.zip&#47;download"><strong>Vienna 2.6<&#47;strong><&#47;a><&#47;h3><&#47;center></p>

--- a/_posts/2012-09-15-vienna-3-beta-with-google-reader-synch.markdown
+++ b/_posts/2012-09-15-vienna-3-beta-with-google-reader-synch.markdown
@@ -12,7 +12,7 @@ author_login: Michael Stroeck
 author_email: michael@stroeck.com
 author_url: http://www.twitter.com/mstroeck
 wordpress_id: 371
-wordpress_url: http://www.vienna-rss.org/?p=371
+wordpress_url: http://www.vienna-rss.com/?p=371
 date: '2012-09-15 11:57:42 +1000'
 date_gmt: '2012-09-15 11:57:42 +1000'
 categories:

--- a/_posts/2012-12-30-beta-binaries-back%e2%80%a6-on-sourceforge.markdown
+++ b/_posts/2012-12-30-beta-binaries-back%e2%80%a6-on-sourceforge.markdown
@@ -6,13 +6,13 @@ title: Vienna beta binaries back&hellip; on SourceForge
 author:
   display_name: barijaona
   login: barijaona
-  email: vienna-rss.org@barijaona.com
+  email: vienna-rss.com@barijaona.com
   url: http://blog.barijaona.com
 author_login: barijaona
-author_email: vienna-rss.org@barijaona.com
+author_email: vienna-rss.com@barijaona.com
 author_url: http://blog.barijaona.com
 wordpress_id: 383
-wordpress_url: http://www.vienna-rss.org/?p=383
+wordpress_url: http://www.vienna-rss.com/?p=383
 date: '2012-12-30 00:41:25 +1100'
 date_gmt: '2012-12-30 00:41:25 +1100'
 categories:

--- a/_posts/2013-03-14-vienna-3-beta-10.markdown
+++ b/_posts/2013-03-14-vienna-3-beta-10.markdown
@@ -6,13 +6,13 @@ title: Vienna 3 Beta 10
 author:
   display_name: barijaona
   login: barijaona
-  email: vienna-rss.org@barijaona.com
+  email: vienna-rss.com@barijaona.com
   url: http://blog.barijaona.com
 author_login: barijaona
-author_email: vienna-rss.org@barijaona.com
+author_email: vienna-rss.com@barijaona.com
 author_url: http://blog.barijaona.com
 wordpress_id: 396
-wordpress_url: http://www.vienna-rss.org/?p=396
+wordpress_url: http://www.vienna-rss.com/?p=396
 date: '2013-03-14 21:32:44 +1100'
 date_gmt: '2013-03-14 21:32:44 +1100'
 categories:

--- a/_posts/2013-06-29-if-you-are-a-google-reader-user%e2%80%a6.markdown
+++ b/_posts/2013-06-29-if-you-are-a-google-reader-user%e2%80%a6.markdown
@@ -6,13 +6,13 @@ title: If you are a Google Reader user&hellip;
 author:
   display_name: barijaona
   login: barijaona
-  email: vienna-rss.org@barijaona.com
+  email: vienna-rss.com@barijaona.com
   url: http://blog.barijaona.com
 author_login: barijaona
-author_email: vienna-rss.org@barijaona.com
+author_email: vienna-rss.com@barijaona.com
 author_url: http://blog.barijaona.com
 wordpress_id: 401
-wordpress_url: http://www.vienna-rss.org/?p=401
+wordpress_url: http://www.vienna-rss.com/?p=401
 date: '2013-06-29 05:04:59 +1000'
 date_gmt: '2013-06-29 05:04:59 +1000'
 categories:

--- a/_posts/2013-07-13-vienna-in-support-of-openness.markdown
+++ b/_posts/2013-07-13-vienna-in-support-of-openness.markdown
@@ -6,14 +6,14 @@ title: Vienna, in support of openness
 author:
   display_name: barijaona
   login: barijaona
-  email: vienna-rss.org@barijaona.com
+  email: vienna-rss.com@barijaona.com
   url: http://blog.barijaona.com
 author_login: barijaona
-author_email: vienna-rss.org@barijaona.com
+author_email: vienna-rss.com@barijaona.com
 author_url: http://blog.barijaona.com
 excerpt: Vienna can sync with BazQux and FeedHQ.
 wordpress_id: 406
-wordpress_url: http://www.vienna-rss.org/?p=406
+wordpress_url: http://www.vienna-rss.com/?p=406
 date: '2013-07-13 06:58:07 +1000'
 date_gmt: '2013-07-13 06:58:07 +1000'
 categories:

--- a/_posts/2013-09-03-vienna-3-beta-16-is-out.markdown
+++ b/_posts/2013-09-03-vienna-3-beta-16-is-out.markdown
@@ -6,13 +6,13 @@ title: Vienna 3 Beta 16 is out
 author:
   display_name: barijaona
   login: barijaona
-  email: vienna-rss.org@barijaona.com
+  email: vienna-rss.com@barijaona.com
   url: http://blog.barijaona.com
 author_login: barijaona
-author_email: vienna-rss.org@barijaona.com
+author_email: vienna-rss.com@barijaona.com
 author_url: http://blog.barijaona.com
 wordpress_id: 413
-wordpress_url: http://www.vienna-rss.org/?p=413
+wordpress_url: http://www.vienna-rss.com/?p=413
 date: '2013-09-03 03:53:24 +1000'
 date_gmt: '2013-09-03 03:53:24 +1000'
 categories:

--- a/_posts/2014-10-25-vienna-3-release-candidate-9-is-out.markdown
+++ b/_posts/2014-10-25-vienna-3-release-candidate-9-is-out.markdown
@@ -11,7 +11,7 @@ author:
 author_login: josh
 author_email: josh64@gmail.com
 wordpress_id: 416
-wordpress_url: http://www.vienna-rss.org/?p=416
+wordpress_url: http://www.vienna-rss.com/?p=416
 date: '2014-10-25 23:41:23 +1100'
 date_gmt: '2014-10-25 23:41:23 +1100'
 categories:

--- a/_posts/2014-11-02-vienna-3-stable-version-is-out.markdown
+++ b/_posts/2014-11-02-vienna-3-stable-version-is-out.markdown
@@ -6,13 +6,13 @@ title: Vienna 3 (stable version) is out
 author:
   display_name: barijaona
   login: barijaona
-  email: vienna-rss.org@barijaona.com
+  email: vienna-rss.com@barijaona.com
   url: http://blog.barijaona.com
 author_login: barijaona
-author_email: vienna-rss.org@barijaona.com
+author_email: vienna-rss.com@barijaona.com
 author_url: http://blog.barijaona.com
 wordpress_id: 428
-wordpress_url: http://www.vienna-rss.org/?p=428
+wordpress_url: http://www.vienna-rss.com/?p=428
 date: '2014-11-02 19:46:26 +1100'
 date_gmt: '2014-11-02 19:46:26 +1100'
 categories:

--- a/_posts/2014-12-01-vienna-is-now-on-irc.markdown
+++ b/_posts/2014-12-01-vienna-is-now-on-irc.markdown
@@ -12,7 +12,7 @@ author_login: josh
 author_email: josh64@gmail.com
 excerpt: 'Vienna is now on the freenode IRC network in the channel #ViennaRSS'
 wordpress_id: 431
-wordpress_url: http://www.vienna-rss.org/?p=431
+wordpress_url: http://www.vienna-rss.com/?p=431
 date: '2014-12-01 07:46:26 +1100'
 date_gmt: '2014-12-01 07:46:26 +1100'
 categories:

--- a/_posts/2015-06-20-vienna-is-not-dead-%f0%9f%98.markdown
+++ b/_posts/2015-06-20-vienna-is-not-dead-%f0%9f%98.markdown
@@ -11,7 +11,7 @@ author:
 author_login: josh
 author_email: josh64@gmail.com
 wordpress_id: 438
-wordpress_url: http://www.vienna-rss.org/?p=438
+wordpress_url: http://www.vienna-rss.com/?p=438
 date: '2015-06-20 02:17:02 +1000'
 date_gmt: '2015-06-20 02:17:02 +1000'
 categories:

--- a/about.md
+++ b/about.md
@@ -23,7 +23,7 @@ categories:
 	Where?
 </h2>
 <p>
-	The project's <a href="http://www.github.com/ViennaRSS/vienna-rss">Git repository</a> is hosted by <a href="http://github.com">GitHub</a>. The easiest way to contact the developers is via the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">Vienna forums</a> at Cocoaforge. For more on how to contribute to the project read this: <a href="http://www.vienna-rss.org/?page_id=16">Vienna Development</a>.
+	The project's <a href="http://www.github.com/ViennaRSS/vienna-rss">Git repository</a> is hosted by <a href="http://github.com">GitHub</a>. The easiest way to contact the developers is via the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">Vienna forums</a> at Cocoaforge. For more on how to contribute to the project read this: <a href="http://www.vienna-rss.com/?page_id=16">Vienna Development</a>.
 </p>
 <h2>
 	Who uses Vienna?
@@ -32,9 +32,9 @@ categories:
 	Actual users are always hard to track, but to date Vienna has been downloaded over 450.000 times from Sourceforge's servers alone. If you are responsible for one of those downloads: Thank you!
 </p>
 <h2>
-	vienna-rss.org?
+	vienna-rss.com?
 </h2>
 <p>
-	vienna-rss.org is graciously hosted by <a href="http://www.sourceforge.net">SourceForge</a>. The website was created by Michael Ströck and is based on a Wordpress theme from <a href="http://www.woothemes.com">WooThemes</a>.
+	vienna-rss.com is graciously hosted by <a href="http://www.sourceforge.net">SourceForge</a>. The website was created by Michael Ströck and is based on a Wordpress theme from <a href="http://www.woothemes.com">WooThemes</a>.
 </p>
 

--- a/development/browse-source-3/index.markdown
+++ b/development/browse-source-3/index.markdown
@@ -7,12 +7,12 @@ author:
   display_name: Vienna Administrators
   login: admin
   email: vienna-rss-admins@sourceforge.net
-  url: http://www.vienna-rss.org
+  url: http://www.vienna-rss.com
 author_login: admin
 author_email: vienna-rss-admins@sourceforge.net
-author_url: http://www.vienna-rss.org
+author_url: http://www.vienna-rss.com
 wordpress_id: 355
-wordpress_url: http://www.vienna-rss.org/?page_id=355
+wordpress_url: http://www.vienna-rss.com/?page_id=355
 date: '2011-08-29 15:32:57 +1000'
 date_gmt: '2011-08-29 15:32:57 +1000'
 categories:

--- a/development/creating-plugins-for-vienna-2-5/index.markdown
+++ b/development/creating-plugins-for-vienna-2-5/index.markdown
@@ -11,7 +11,7 @@ author:
 author_login: Steve Palmer
 author_email: stevewpalmer@gmail.com
 wordpress_id: 120
-wordpress_url: http://www.vienna-rss.org/?page_id=120
+wordpress_url: http://www.vienna-rss.com/?page_id=120
 date: '2010-01-16 15:09:09 +1100'
 date_gmt: '2010-01-16 15:09:09 +1100'
 categories:
@@ -21,27 +21,27 @@ comments:
 - id: 13
   author: A Vienna 2.5 Sneak Peek&nbsp;|&nbsp;Vienna RSS
   author_email: ''
-  author_url: http://www.vienna-rss.org/?p=201
+  author_url: http://www.vienna-rss.com/?p=201
   date: '2010-01-18 12:02:05 +1100'
   date_gmt: '2010-01-18 12:02:05 +1100'
   content: "[...] Creating Plugins (v2.5) [...]"
 - id: 65
   author: Vienna 2.5 BETA&nbsp;|&nbsp;Vienna RSS
   author_email: ''
-  author_url: http://www.vienna-rss.org/?p=237
+  author_url: http://www.vienna-rss.com/?p=237
   date: '2010-02-08 13:07:15 +1100'
   date_gmt: '2010-02-08 13:07:15 +1100'
   content: "[...] Creating Plugins (v2.5) [...]"
 - id: 411
   author: Vienna 2.5 &#8211; The Social Sharing Edition&nbsp;|&nbsp;Vienna RSS
   author_email: ''
-  author_url: http://www.vienna-rss.org/?p=285
+  author_url: http://www.vienna-rss.com/?p=285
   date: '2010-03-19 09:18:42 +1100'
   date_gmt: '2010-03-19 09:18:42 +1100'
   content: "[...] Creating Plugins (v2.5) [...]"
 ---
 <p>Starting with v2.5 and later, Vienna supports plugins which are installed on the toolbar and can run defined actions. These plugins are XML-based and can be created by editing a simple <a href="http://developer.apple.com/mac/library/documentation/Cocoa/Conceptual/PropertyLists/UnderstandXMLPlist/UnderstandXMLPlist.html">.plist-file</a> without any knowledge of Cocoa programming, in as little as 15 minutes.  This section describes how to create your own plugins, which will look and work exactly like the built-in ones:<br />
-<center><img alt="Vienna 2.5 supports user-creatable plugins" src="http://www.vienna-rss.org/img/plugins.png" title="Vienna 2.5 supports user-creatable plugins" width="327" height="77" /></center></p>
+<center><img alt="Vienna 2.5 supports user-creatable plugins" src="http://www.vienna-rss.com/img/plugins.png" title="Vienna 2.5 supports user-creatable plugins" width="327" height="77" /></center></p>
 <p><br><br />
 <h2>Creating the Plugin Bundle</h2><br />
 Vienna plugins are distributed in the form of folders with the extension "<strong>.viennaplugin</strong>", which OS X automatically treats as bundles. Simply create a new folder, named like your new plugin. Then edit its name and append ".viennaplugin". This registers the folder as a Vienna plugin folder so that it can be double-clicked or dragged-and-dropped on the Vienna application icon to automatically install it. After this step, you can view the folder's contents via control/right-clicking and choosing "Show Package Contents" from the menu.</p>
@@ -105,7 +105,7 @@ The actual configuration of the plugin happens in its "info.plist". The followin
 <li><strong>Name</strong>: (mandatory) this is a short, internal, name that uniquely identifies the plugin. It is now displayed in the UI.</li>
 <li><strong>Type</strong>: (mandatory) this specifies the plugin type. Three values are accepted: <strong>Link</strong>,  <strong>Script</strong> and <strong>BlogEditor</strong>.</li>
 <li><strong>BundleIdentifier</strong>: Only used for BlogEditor plugins, this defines the identifier of the application that you want to be called.</li>
-<li><strong>URL</strong>: (mandatory for link-type plugins) this is the URL that is browed when the plugin button is clicked. Vienna substitutes the $...$ placeholders with actual values from the current article being viewed. See <a href="http://www.vienna-rss.org/?page_id=65">here</a> for a list of placeholders.</li>
+<li><strong>URL</strong>: (mandatory for link-type plugins) this is the URL that is browed when the plugin button is clicked. Vienna substitutes the $...$ placeholders with actual values from the current article being viewed. See <a href="http://www.vienna-rss.com/?page_id=65">here</a> for a list of placeholders.</li>
 <li><strong>Script</strong>: (mandatory for script-type plugins) this is the name of the script file in the same folder as the info.plist.</li>
 <li><strong>Default</strong>: if this is set to true then this plugin appears on the default toolbar.</li>
 <li><strong>FriendlyName</strong>: this is the short name of the plugin that appears as the plugin button text on the toolbar. It should be kept as short as possible. If omitted, the internal name is used instead.</li>

--- a/extras/creating-custom-styles/index.markdown
+++ b/extras/creating-custom-styles/index.markdown
@@ -7,12 +7,12 @@ author:
   display_name: Vienna Administrators
   login: admin
   email: vienna-rss-admins@sourceforge.net
-  url: http://www.vienna-rss.org
+  url: http://www.vienna-rss.com
 author_login: admin
 author_email: vienna-rss-admins@sourceforge.net
-author_url: http://www.vienna-rss.org
+author_url: http://www.vienna-rss.com
 wordpress_id: 65
-wordpress_url: http://www.vienna-rss.org/?page_id=65
+wordpress_url: http://www.vienna-rss.com/?page_id=65
 date: '2010-01-09 12:52:14 +1100'
 date_gmt: '2010-01-09 12:52:14 +1100'
 categories:

--- a/extras/index.markdown
+++ b/extras/index.markdown
@@ -7,12 +7,12 @@ author:
   display_name: Vienna Administrators
   login: admin
   email: vienna-rss-admins@sourceforge.net
-  url: http://www.vienna-rss.org
+  url: http://www.vienna-rss.com
 author_login: admin
 author_email: vienna-rss-admins@sourceforge.net
-author_url: http://www.vienna-rss.org
+author_url: http://www.vienna-rss.com
 wordpress_id: 76
-wordpress_url: http://www.vienna-rss.org/?page_id=76
+wordpress_url: http://www.vienna-rss.com/?page_id=76
 date: '2010-01-09 13:48:40 +1100'
 date_gmt: '2010-01-09 13:48:40 +1100'
 categories:
@@ -32,7 +32,7 @@ See the [Creating Custom Styles](/extras/creating-custom-styles/) page for instr
 		<a href="userstyles/FeedLightAqua.viennastyle.zip"><b>FeedLight Aqua</b></a> The current default theme in Vienna, contributed by <a href="http://graphr.net/">Alex Hong</a>
 	</li>
 	<li>
-	   <a href="http://www.vienna-rss.org/userstyles/JustSimple.viennastyle.zip"><b>Just Simple</b></a>, contributed by <a href="https://www.danielhutnan.com">Daniel Hutnan</a>
+	   <a href="http://www.vienna-rss.com/userstyles/JustSimple.viennastyle.zip"><b>Just Simple</b></a>, contributed by <a href="https://www.danielhutnan.com">Daniel Hutnan</a>
 	</li>
 	<li>
 		<a href="userstyles/GreyMonday.viennastyle.zip"><b>Grey Monday</b></a> Contributed by Mario Peischl

--- a/faq.md
+++ b/faq.md
@@ -33,7 +33,7 @@ categories:
 	<a name="Where_do_I_get_the_Vienna_source_code" id="Where_do_I_get_the_Vienna_source_code">Where do I get the Vienna source code?</a>
 </h2>
 
-See the [Development page](http://www.vienna-rss.org/?page_id=16) for instructions on getting the source code for Vienna. The source code is freely available if you're interested in learning how Vienna works, if you want to build your own copy of Vienna from scratch on your own machine or if you want to borrow portions for inclusion in your own project. The source is provided under the [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0.html).
+See the [Development page](http://www.vienna-rss.com/?page_id=16) for instructions on getting the source code for Vienna. The source code is freely available if you're interested in learning how Vienna works, if you want to build your own copy of Vienna from scratch on your own machine or if you want to borrow portions for inclusion in your own project. The source is provided under the [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0.html).
 
 <h2>
 	<a name="I_found_a_problem_with_Vienna._How_do_I_report_it" id="I_found_a_problem_with_Vienna._How_do_I_report_it">I found a problem with Vienna. How do I report it?</a>
@@ -49,7 +49,7 @@ Fixes for bugs take priority over new features so if your problem is confirmed t
 	<a name="How_do_I_create_my_own_styles" id="How_do_I_create_my_own_styles">How do I create my own styles?</a>
 </h2>
 
-See the [Custom Styles page](http://www.vienna-rss.org/?page_id=65) for instructions.
+See the [Custom Styles page](http://www.vienna-rss.com/?page_id=65) for instructions.
 
 <h2>
 	<a name="How_do_I_create_my_own_scripts" id="How_do_I_create_my_own_scripts">How do I create my own scripts?</a>
@@ -63,7 +63,7 @@ To submit your own script, create a post about it in the [forum](http://www.coco
 	<a name="How_do_I_create_my_own_plugins" id="How_do_I_create_my_own_plugins">How do I create my own plugins?</a>
 </h2>
 
-You can create plugins as easily as editing a single plugin file and no scripting needed. See the [Creating Plugins](http://www.vienna-rss.org/?page_id=120) page for more details. You can also package and share your plugins with others on the forum.
+You can create plugins as easily as editing a single plugin file and no scripting needed. See the [Creating Plugins](http://www.vienna-rss.com/?page_id=120) page for more details. You can also package and share your plugins with others on the forum.
 
 <h2>
 	<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed" id="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">How can I see what happened when my subscriptions are refreshed?</a>

--- a/forum/index.markdown
+++ b/forum/index.markdown
@@ -7,12 +7,12 @@ author:
   display_name: Vienna Administrators
   login: admin
   email: vienna-rss-admins@sourceforge.net
-  url: http://www.vienna-rss.org
+  url: http://www.vienna-rss.com
 author_login: admin
 author_email: vienna-rss-admins@sourceforge.net
-author_url: http://www.vienna-rss.org
+author_url: http://www.vienna-rss.com
 wordpress_id: 89
-wordpress_url: http://www.vienna-rss.org/?page_id=89
+wordpress_url: http://www.vienna-rss.com/?page_id=89
 date: '2010-01-09 15:43:12 +1100'
 date_gmt: '2010-01-09 15:43:12 +1100'
 categories:

--- a/sparkle-files/changelog.xml
+++ b/sparkle-files/changelog.xml
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
 	<channel>
 		<title>Vienna Changelog</title>
-		<link>http://www.vienna-rss.org/</link>
+		<link>http://www.vienna-rss.com/</link>
 		<description>Vienna Changelog</description>
 		<language>en-us</language>
 		<copyright>Copyright 2010-2015, Steve Palmer and contributors</copyright>

--- a/sparkle-files/changelog_beta.xml
+++ b/sparkle-files/changelog_beta.xml
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
 	<channel>
 		<title>Vienna Changelog</title>
-		<link>http://www.vienna-rss.org/</link>
+		<link>http://www.vienna-rss.com/</link>
 		<description>Vienna Changelog</description>
 		<language>en-us</language>
 		<copyright>Copyright 2010-2015, Steve Palmer and contributors</copyright>

--- a/sparkle-files/changelog_rc.xml
+++ b/sparkle-files/changelog_rc.xml
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
 	<channel>
 		<title>Vienna Changelog</title>
-		<link>http://www.vienna-rss.org/</link>
+		<link>http://www.vienna-rss.com/</link>
 		<description>Vienna Changelog</description>
 		<language>en-us</language>
 		<copyright>Copyright 2010-2015, Steve Palmer and contributors</copyright>


### PR DESCRIPTION
vienna-rss.org has expired, vienna-rss.com was registered instead.
If we get control of vienna-rs.org we can redirect to .com.

Fixes viennarss/vienna-rss#796

