### PR TITLE
Swap Bintray URLs with GitHub URLs

### DIFF
--- a/sparkle-files/changelog.xml
+++ b/sparkle-files/changelog.xml
@@ -9,9 +9,9 @@
 		<item>
 			<title>Vienna 3.7.1 :d356d926:</title>
 			<pubDate>Sat, 09 Jan 2021 11:12:21 +0000</pubDate>
-			<link>https://dl.bintray.com/viennarss/vienna-rss/Vienna3.7.1.tar.gz</link>
+			<link>https://github.com/ViennaRSS/vienna-rss/releases/tag/v%2F3.7.1</link>
 			<sparkle:minimumSystemVersion>10.11.0</sparkle:minimumSystemVersion>
-			<enclosure url="https://dl.bintray.com/viennarss/vienna-rss/Vienna3.7.1.tar.gz" sparkle:version="7437" sparkle:shortVersionString="3.7.1 :d356d926:" length="12992793" sparkle:dsaSignature="MC4CFQCS0AEcz5t+W+cnno6dxL/sCwNLCAIVALLbiSx8beTQW8J1PlEBQVbXBfmo" type="application/octet-stream"/>
+			<enclosure url="https://github.com/ViennaRSS/vienna-rss/releases/download/v%2F3.7.1/Vienna3.7.1.tar.gz" sparkle:version="7437" sparkle:shortVersionString="3.7.1 :d356d926:" length="12992793" sparkle:dsaSignature="MC4CFQCS0AEcz5t+W+cnno6dxL/sCwNLCAIVALLbiSx8beTQW8J1PlEBQVbXBfmo" type="application/octet-stream"/>
 			<sparkle:releaseNotesLink>https://viennarss.github.io/sparkle-files/noteson3.7.1.html</sparkle:releaseNotesLink>
 		</item>
 	</channel>

--- a/sparkle-files/changelog_beta.xml
+++ b/sparkle-files/changelog_beta.xml
@@ -9,9 +9,9 @@
 		<item>
 			<title>Vienna 3.7.1 :d356d926:</title>
 			<pubDate>Sat, 09 Jan 2021 11:12:21 +0000</pubDate>
-			<link>https://dl.bintray.com/viennarss/vienna-rss/Vienna3.7.1.tar.gz</link>
+			<link>https://github.com/ViennaRSS/vienna-rss/releases/tag/v%2F3.7.1</link>
 			<sparkle:minimumSystemVersion>10.11.0</sparkle:minimumSystemVersion>
-			<enclosure url="https://dl.bintray.com/viennarss/vienna-rss/Vienna3.7.1.tar.gz" sparkle:version="7437" sparkle:shortVersionString="3.7.1 :d356d926:" length="12992793" sparkle:dsaSignature="MC4CFQCS0AEcz5t+W+cnno6dxL/sCwNLCAIVALLbiSx8beTQW8J1PlEBQVbXBfmo" type="application/octet-stream"/>
+			<enclosure url="https://github.com/ViennaRSS/vienna-rss/releases/download/v%2F3.7.1/Vienna3.7.1.tar.gz" sparkle:version="7437" sparkle:shortVersionString="3.7.1 :d356d926:" length="12992793" sparkle:dsaSignature="MC4CFQCS0AEcz5t+W+cnno6dxL/sCwNLCAIVALLbiSx8beTQW8J1PlEBQVbXBfmo" type="application/octet-stream"/>
 			<sparkle:releaseNotesLink>https://viennarss.github.io/sparkle-files/noteson3.7.1.html</sparkle:releaseNotesLink>
 		</item>
 	</channel>

--- a/sparkle-files/changelog_rc.xml
+++ b/sparkle-files/changelog_rc.xml
@@ -9,9 +9,9 @@
 		<item>
 			<title>Vienna 3.7.1 :d356d926:</title>
 			<pubDate>Sat, 09 Jan 2021 11:12:21 +0000</pubDate>
-			<link>https://dl.bintray.com/viennarss/vienna-rss/Vienna3.7.1.tar.gz</link>
+			<link>https://github.com/ViennaRSS/vienna-rss/releases/tag/v%2F3.7.1</link>
 			<sparkle:minimumSystemVersion>10.11.0</sparkle:minimumSystemVersion>
-			<enclosure url="https://dl.bintray.com/viennarss/vienna-rss/Vienna3.7.1.tar.gz" sparkle:version="7437" sparkle:shortVersionString="3.7.1 :d356d926:" length="12992793" sparkle:dsaSignature="MC4CFQCS0AEcz5t+W+cnno6dxL/sCwNLCAIVALLbiSx8beTQW8J1PlEBQVbXBfmo" type="application/octet-stream"/>
+			<enclosure url="https://github.com/ViennaRSS/vienna-rss/releases/download/v%2F3.7.1/Vienna3.7.1.tar.gz" sparkle:version="7437" sparkle:shortVersionString="3.7.1 :d356d926:" length="12992793" sparkle:dsaSignature="MC4CFQCS0AEcz5t+W+cnno6dxL/sCwNLCAIVALLbiSx8beTQW8J1PlEBQVbXBfmo" type="application/octet-stream"/>
 			<sparkle:releaseNotesLink>https://viennarss.github.io/sparkle-files/noteson3.7.1.html</sparkle:releaseNotesLink>
 		</item>
 	</channel>


### PR DESCRIPTION
Bintray is discontinued as of 1 May 2021. For now, GitHub URLs are used to download Sparkle assets.

Resolves ViennaRSS/vienna-rss#1434