### PR TITLE
Remove Google Fonts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,11 +11,6 @@
   }}" />
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 
-  <link
-    href="http://fonts.googleapis.com/css?family=Lato:300,400,400italic,600,700|Raleway:300,400,500,600,700|Crete+Round:400italic"
-    rel="stylesheet"
-    type="text/css"
-  />
   <link rel="stylesheet" href="/css/bootstrap.css" type="text/css" />
 
   <link rel="stylesheet" href="/css/dark.css" type="text/css" />

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -23,9 +23,9 @@ $margin-big:                    80px;
 
 //-------------------- Font Families --------------------//
 
-$body-font:                     'Lato', sans-serif;
-$heading-font:                  'Raleway', sans-serif;
-$secondary-font:                'Crete Round', serif;
+$body-font:                     ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+$heading-font:                  $body-font;
+$secondary-font:                ui-serif, Georgia, serif;
 
 
 //-------------------- Font Sizes --------------------//


### PR DESCRIPTION
I used the Apple system fonts instead, falling back to Helvetica Neue or an unspecified sans-serif font on old systems.