### PR TITLE
Replace most links to the Cocoaforge forum with links to GitHub

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,9 @@ baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://www.vienna-rss.com" # the base hostname & protocol for your site
 twitter_username: ViennaRSS
 github_username:  ViennaRSS
+app_github_url: https://github.com/ViennaRSS/vienna-rss
+site_github_url: https://github.com/ViennaRSS/viennarss.github.io
+forum_url: https://forums.cocoaforge.com/viewforum.php?f=18
 
 # Build settings
 markdown: kramdown

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -41,7 +41,6 @@
 								<li><a href="{{ "/extras/creating-custom-styles" | prepend: site.baseurl }}">Custom Styles</a></li>
 							</ul>
 						</li>
-						  <li><a href="https://forums.cocoaforge.com/viewforum.php?f=18">Forum</a></li>
 						  <li><a href="{{ "/support" | prepend: site.baseurl }}">Get Support</a></li>
 						</ul>
 					</div>

--- a/about.md
+++ b/about.md
@@ -9,15 +9,15 @@ date: '2019-02-11 22:15:0 +1100'
 
 ## What?
 
-Vienna is an [RSS/Atom reader](https://en.wikipedia.org/wiki/News_aggregator) for macOS, packed with powerful features that help you make sense of the flood of information that is distributed via these formats today. The Vienna Project is continuously being improved and updated, so keep up to date with current development on [the forums](https://forums.cocoaforge.com/viewforum.php?f=18).
+Vienna is an [RSS/Atom reader](https://en.wikipedia.org/wiki/News_aggregator) for macOS, packed with powerful features that help you make sense of the flood of information that is distributed via these formats today. The Vienna Project is continuously being improved and updated, so keep up to date with current development on our [GitHub page]({{ site.app_github_url }}).
 
-Vienna is native macOS Open Source project published under the [Apache Licence, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0). It was started by Steve Palmer, aka [stevepa](https://forums.cocoaforge.com/memberlist.php?mode=viewprofile&u=5718) and is currently in active development by Barijoana, Josh, and others. Many others have contributed immensely to this project, for details please download the application and load its "Acknowledgements".
+Vienna is a native macOS open-source project published under the [Apache Licence, version 2.0](https://www.apache.org/licenses/LICENSE-2.0). It was started by Steve Palmer, aka [stevepa](https://forums.cocoaforge.com/memberlist.php?mode=viewprofile&u=5718) and is currently in active development by Barijoana, Josh, and others. Many others have contributed immensely to this project, for details please download the application and load its "Acknowledgements".
 
 Companies which have supported the project include [GitHub](https://www.github.com) and [SourceForge](https://www.sourceforge.net) (who previously provided all our web-hosting).
 
 ## Where?
 
-The project's [Git repository](https://github.com/ViennaRSS/vienna-rss) is hosted by [GitHub](https://www.github.com). The easiest way to contact the developers is via [GitHub issues](https://github.com/ViennaRSS/vienna-rss/issues) or the [Vienna forums](https://forums.cocoaforge.com/viewforum.php?f=18) at Cocoaforge. For more on how to contribute to the project read this: [Vienna Development](/development).
+The project's [git repository]({{ site.app_github_url }}) is hosted by [GitHub](https://www.github.com). The easiest way to contact the developers is via [GitHub issues]({{ site.app_github_url }}/issues) or [GitHub Discussions]({{ site.app_github_url }}/discussions). For more on how to contribute to the project read this: [Vienna Development](/development).
 
 ## Who uses Vienna?
 

--- a/archive/forum.md
+++ b/archive/forum.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 status: publish
-published: true
+published: false
 title: Forum
 author:
   display_name: Vienna Administrators

--- a/extras/creating-custom-styles/index.markdown
+++ b/extras/creating-custom-styles/index.markdown
@@ -48,7 +48,7 @@ You can have additional files such as images, but these two files must be presen
 The parts in `$...$` are special placeholders, called **tags**, that Vienna will fill in when it displays the article. After you have created your style, restart Vienna and your new style should appear on the Styles submenu. Switch to it see your finished work.
 
 ### Available Tags
-The following is a complete list of the tags currently available to you. They are named to be self-explanatory. If you have an idea for a style that would need the application to expose additional information, please bring it up on the [Developer Forum](https://forums.cocoaforge.com/viewforum.php?f=18) or create a new issue on [GitHub](https://github.com/ViennaRSS/vienna-rss/issues).
+The following is a complete list of the tags currently available to you. They are named to be self-explanatory. If you have an idea for a style that would need the application to expose additional information, please bring it up on the [GitHub Discussions page]({{ site.app_github_url }}/discussions) or create a new issue on [GitHub]({{ site.app_github_url }}/discussions/issues).
 
 * `$ArticleLink$`
 * `$ArticleTitle$`

--- a/faq.md
+++ b/faq.md
@@ -39,7 +39,7 @@ See the [Development page](http://www.vienna-rss.com/?page_id=16) for instructio
 	<a name="I_found_a_problem_with_Vienna._How_do_I_report_it" id="I_found_a_problem_with_Vienna._How_do_I_report_it">I found a problem with Vienna. How do I report it?</a>
 </h2>
 
-Create a new issue over at our [GitHub](https://github.com/ViennaRSS/vienna-rss/issues) site, or post a message over in the [forum](http://www.cocoaforge.com/viewforum.php?f=18) and somebody will investigate. Provide as much information about the problem as you can including: the build of Vienna (obtained from the About Vienna panel), steps to reproduce and what you expected to happen. If the problem occurs with a specific news feed, always include the URL of the feed. It is easier to fix problems that we can reproduce.
+Create a new issue or start a discussion over on our [GitHub page]({{ site.app_github_url }}) and somebody will investigate or respond. Provide as much information about the problem as you can including: the build of Vienna (obtained from the About Vienna panel), steps to reproduce and what you expected to happen. If the problem occurs with a specific news feed, always include the URL of the feed. It is easier to fix problems that we can reproduce.
 
 Make sure you're always running the most recent build of Vienna. The Check for Updates command will report if there's a newer build available than the one you have.
 
@@ -57,13 +57,13 @@ See the [Custom Styles page](http://www.vienna-rss.com/?page_id=65) for instruct
 
 Vienna's scripts are written using AppleScript. See the [Apple resource page](http://www.apple.com/macosx/features/applescript/resources.html) for more details. Also take a look at the Vienna scripting dictionary and examples of what you can accomplish.
 
-To submit your own script, create a post about it in the [forum](http://www.cocoaforge.com/viewforum.php?f=18) and after it has been reviewed, it will be made available on the Downloads page.
+To submit your own script, create an issue or a pull request on our [GitHub page]({{ site.site_github_url }}). After it has been reviewed and accepted, it will be made available on the Extras page.
 
 <h2>
 	<a name="How_do_I_create_my_own_plugins" id="How_do_I_create_my_own_plugins">How do I create my own plugins?</a>
 </h2>
 
-You can create plugins as easily as editing a single plugin file and no scripting needed. See the [Creating Plugins](http://www.vienna-rss.com/?page_id=120) page for more details. You can also package and share your plugins with others on the forum.
+You can create plugins as easily as editing a single plugin file and no scripting needed. See the [Creating Plugins](http://www.vienna-rss.com/?page_id=120) page for more details. You can also package and share your plugins with others.
 
 <h2>
 	<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed" id="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">How can I see what happened when my subscriptions are refreshed?</a>
@@ -97,7 +97,7 @@ It means that Vienna got a feed back from the subscription that it couldn't inte
 2. The feed itself may contain malformed XML. Some subscriptions make a mistake in putting together the XML that makes up the feed and Vienna cannot interpret malformed XML. Use the Validate Feed command on the File menu to see if this is the case. Unfortunately you cannot do much about this in Vienna except wait for the feed itself to be corrected by the site.<br />
 3. The feed may be incomplete. If the refresh was interrupted then the XML data will be incomplete and will appear malformed in Vienna. A second refresh may correct this problem.
 
-If none of the above explain the problem, post a message on the support forum with the URL of the feed exhibiting the problem.
+If none of the above explain the problem, create a issue on the [GitHub page]({{ site.app_github_url }}/issues) with the URL of the feed exhibiting the problem.
 
 <h2>
 	<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_" id="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">Is there a shortcut key for going to the next article, marking read, etc?</a>
@@ -123,4 +123,4 @@ Auto-expire will NOT remove unread or flagged articles. It assumes that you have
 	<a name="How_do_I_request_an_enhancement_in_Vienna" id="How_do_I_request_an_enhancement_in_Vienna">How do I request an enhancement in Vienna?</a>
 </h2>
 
-Create a new issue over at our [GitHub](https://github.com/ViennaRSS/vienna-rss/issues) site, or post a message over at the [support forum](http://forums.cocoaforge.com/viewforum.php?f=18). All requested enhancements are logged in the TODO file that is included with the source code as a guidance for future developers.
+Start a discussion on our [GitHub Discussions]({{ site.app_github_url }}/discussions) page.

--- a/support.md
+++ b/support.md
@@ -8,5 +8,6 @@ date: '2010-01-08 22:57:49 +1100'
 categories:
 ---
 
-If the in-application help files and the [FAQ](faq.html) don't answer your questions, head over to our [Support Forum](http://forums.cocoaforge.com/viewforum.php?f=18) which is hosted by [Cocoaforge](http://www.cocoaforge.com). Posting your question, comment, bug report or feature request there will ensure that the developers see it. Using the forum also ensures that the answer will help other users as well.
+If the in-application help files and the [FAQ page](faq.html) don't answer your questions, head over to our [GitHub page]({{ site.app_github_url }}). You can use the search field to look for reported issues or user discussions. Create an [issue]({{ site.app_github_url }}/issues) to report a problem/bug or start a [discussion]({{ site.app_github_url }}/discussions) to suggest a feature or ask a question. Using GitHub ensures that the developers see it and helps other users as well.
 
+You can also use the [forum at Cocoaforge]({{ site.forum_url }}). Please be aware that this forum may not be checked as often by Vienna's developers.


### PR DESCRIPTION
This points users to the GitHub page instead of the Cocoaforge forums. It has happened numerous times that the forums aren't available (as is the case right now) due to: expired certificate, expired website hosting, expired domain registration. These are issues outside of our control. Moreover, I noticed that the forums are rarely used by us, leaving posts unnoticed for some time or unanswered.

The forum is still mentioned on the "Get Support" page, but with a note that it may not be checked as often.