### PR TITLE
Fix redirects to include the slug that ends with /

### DIFF
--- a/development/creating-plugins.md
+++ b/development/creating-plugins.md
@@ -40,7 +40,7 @@ comments:
   date_gmt: '2010-03-19 09:18:42 +1100'
   content: "[...] Creating Plugins (v2.5) [...]"
 redirect_from:
-  - /development/creating-plugins-for-vienna-2-5
+  - /development/creating-plugins-for-vienna-2-5/
 ---
 <p>Starting with v2.5 and later, Vienna supports plugins which are installed on the toolbar and can run defined actions. These plugins are XML-based and can be created by editing a simple <a href="https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/PropertyLists/UnderstandXMLPlist/UnderstandXMLPlist.html">.plist-file</a> without any knowledge of Cocoa programming, in as little as 15 minutes.  This section describes how to create your own plugins, which will look and work exactly like the built-in ones:<br />
 <center><img alt="Vienna 2.5 supports user-creatable plugins" src="{{ '/images/plugins.png' | prepend: site.baseurl }}" title="Vienna 2.5 supports user-creatable plugins" width="327" height="77" /></center></p>

--- a/development/creating-styles.md
+++ b/development/creating-styles.md
@@ -20,7 +20,7 @@ categories:
 tags: []
 comments: []
 redirect_from:
-  - /extras/creating-custom-styles
+  - /extras/creating-custom-styles/
 ---
 
 Vienna supports a variety of different display styles for articles. These styles are provided on the Styles sub-menu off the View menu. A style is a combination of an [HTML](http://en.wikipedia.org/wiki/HTML) template that is used to control the placement of various parts of the article and a [CSS](http://en.wikipedia.org/wiki/Cascading_Style_Sheets) stylesheet that controls the appearance of the article.


### PR DESCRIPTION
Not including the / leads to a 404 error when the slug with the / is requested. Now both the slug with and without the / are redirected.