### PR TITLE
Unpublish Vienna 3.10.7 due to crash on macOS 10.13 and 10.14

### DIFF
--- a/sparkle-files/changelog.xml
+++ b/sparkle-files/changelog.xml
@@ -7,14 +7,14 @@
 		<language>en-us</language>
 		<copyright>Copyright 2010-2025, Steve Palmer and contributors</copyright>
 		<item>
-			<title>Vienna 3.10.7 :c30871c7:</title>
-			<pubDate>Sat, 04 Jul 2026 10:49:37 +0000</pubDate>
-			<link>https://github.com/ViennaRSS/vienna-rss/releases/tag/v%2F3.10.7</link>
-			<sparkle:version>9187</sparkle:version>
-			<sparkle:shortVersionString>3.10.7 :c30871c7:</sparkle:shortVersionString>
+			<title>Vienna 3.10.6 :284aab65:</title>
+			<pubDate>Sat, 30 May 2026 10:53:34 +0000</pubDate>
+			<link>https://github.com/ViennaRSS/vienna-rss/releases/tag/v%2F3.10.6</link>
+			<sparkle:version>9176</sparkle:version>
+			<sparkle:shortVersionString>3.10.6 :284aab65:</sparkle:shortVersionString>
 			<sparkle:minimumSystemVersion>10.13.0</sparkle:minimumSystemVersion>
-			<enclosure url="https://downloads.sourceforge.net/project/vienna-rss/v_3.10.7/Vienna3.10.7.dmg" sparkle:edSignature="9c8GDHNewZTAcCThT/jTEpWYakJM/umXRQyhJ2X0ry3oBufq+9vnzcjFlmf4RAN8OXDxUNE4kZPxNO6RB2kADQ==" length="9266855" type="application/octet-stream" />
-			<sparkle:releaseNotesLink>https://www.vienna-rss.com/sparkle-files/noteson3.10.7.html</sparkle:releaseNotesLink>
+			<enclosure url="https://downloads.sourceforge.net/project/vienna-rss/v_3.10.6/Vienna3.10.6.dmg" sparkle:edSignature="W0y1QJ41UPn16GJtwYR4EVjj5vUjfKhQyQ2yJZCniencynAUHCaOaEROnFWNYgBN16Aa8MVkynFDkRPoFqXEDw==" length="9192468" type="application/octet-stream" />
+			<sparkle:releaseNotesLink>https://www.vienna-rss.com/sparkle-files/noteson3.10.6.html</sparkle:releaseNotesLink>
 		</item>
 		<item>
 			<title>Vienna 3.8.8 :de36b0c7:</title>

--- a/sparkle-files/changelog_beta.xml
+++ b/sparkle-files/changelog_beta.xml
@@ -17,14 +17,14 @@
 			<sparkle:releaseNotesLink>https://www.vienna-rss.com/sparkle-files/noteson3.11.0_beta3.html</sparkle:releaseNotesLink>
 		</item>
 		<item>
-			<title>Vienna 3.10.7 :c30871c7:</title>
-			<pubDate>Sat, 04 Jul 2026 10:49:37 +0000</pubDate>
-			<link>https://github.com/ViennaRSS/vienna-rss/releases/tag/v%2F3.10.7</link>
-			<sparkle:version>9187</sparkle:version>
-			<sparkle:shortVersionString>3.10.7 :c30871c7:</sparkle:shortVersionString>
+			<title>Vienna 3.10.6 :284aab65:</title>
+			<pubDate>Sat, 30 May 2026 10:53:34 +0000</pubDate>
+			<link>https://github.com/ViennaRSS/vienna-rss/releases/tag/v%2F3.10.6</link>
+			<sparkle:version>9176</sparkle:version>
+			<sparkle:shortVersionString>3.10.6 :284aab65:</sparkle:shortVersionString>
 			<sparkle:minimumSystemVersion>10.13.0</sparkle:minimumSystemVersion>
-			<enclosure url="https://downloads.sourceforge.net/project/vienna-rss/v_3.10.7/Vienna3.10.7.dmg" sparkle:edSignature="9c8GDHNewZTAcCThT/jTEpWYakJM/umXRQyhJ2X0ry3oBufq+9vnzcjFlmf4RAN8OXDxUNE4kZPxNO6RB2kADQ==" length="9266855" type="application/octet-stream" />
-			<sparkle:releaseNotesLink>https://www.vienna-rss.com/sparkle-files/noteson3.10.7.html</sparkle:releaseNotesLink>
+			<enclosure url="https://downloads.sourceforge.net/project/vienna-rss/v_3.10.6/Vienna3.10.6.dmg" sparkle:edSignature="W0y1QJ41UPn16GJtwYR4EVjj5vUjfKhQyQ2yJZCniencynAUHCaOaEROnFWNYgBN16Aa8MVkynFDkRPoFqXEDw==" length="9192468" type="application/octet-stream" />
+			<sparkle:releaseNotesLink>https://www.vienna-rss.com/sparkle-files/noteson3.10.6.html</sparkle:releaseNotesLink>
 		</item>
 		<item>
 			<title>Vienna 3.8.8 :de36b0c7:</title>

--- a/sparkle-files/changelog_rc.xml
+++ b/sparkle-files/changelog_rc.xml
@@ -7,14 +7,14 @@
 		<language>en-us</language>
 		<copyright>Copyright 2010-2025, Steve Palmer and contributors</copyright>
 		<item>
-			<title>Vienna 3.10.7 :c30871c7:</title>
-			<pubDate>Sat, 04 Jul 2026 10:49:37 +0000</pubDate>
-			<link>https://github.com/ViennaRSS/vienna-rss/releases/tag/v%2F3.10.7</link>
-			<sparkle:version>9187</sparkle:version>
-			<sparkle:shortVersionString>3.10.7 :c30871c7:</sparkle:shortVersionString>
+			<title>Vienna 3.10.6 :284aab65:</title>
+			<pubDate>Sat, 30 May 2026 10:53:34 +0000</pubDate>
+			<link>https://github.com/ViennaRSS/vienna-rss/releases/tag/v%2F3.10.6</link>
+			<sparkle:version>9176</sparkle:version>
+			<sparkle:shortVersionString>3.10.6 :284aab65:</sparkle:shortVersionString>
 			<sparkle:minimumSystemVersion>10.13.0</sparkle:minimumSystemVersion>
-			<enclosure url="https://downloads.sourceforge.net/project/vienna-rss/v_3.10.7/Vienna3.10.7.dmg" sparkle:edSignature="9c8GDHNewZTAcCThT/jTEpWYakJM/umXRQyhJ2X0ry3oBufq+9vnzcjFlmf4RAN8OXDxUNE4kZPxNO6RB2kADQ==" length="9266855" type="application/octet-stream" />
-			<sparkle:releaseNotesLink>https://www.vienna-rss.com/sparkle-files/noteson3.10.7.html</sparkle:releaseNotesLink>
+			<enclosure url="https://downloads.sourceforge.net/project/vienna-rss/v_3.10.6/Vienna3.10.6.dmg" sparkle:edSignature="W0y1QJ41UPn16GJtwYR4EVjj5vUjfKhQyQ2yJZCniencynAUHCaOaEROnFWNYgBN16Aa8MVkynFDkRPoFqXEDw==" length="9192468" type="application/octet-stream" />
+			<sparkle:releaseNotesLink>https://www.vienna-rss.com/sparkle-files/noteson3.10.6.html</sparkle:releaseNotesLink>
 		</item>
 		<item>
 			<title>Vienna 3.8.8 :de36b0c7:</title>


### PR DESCRIPTION
This partially reverts commits 9f8a6393e959ee46270df08888ddb7cdda7cf43a and ecaa572b1a63c79d25ced2aa9a65a3498ba83f5d.